### PR TITLE
Added max storage size parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,5 +19,5 @@ npm install --save redux-persist-node-storage
 import { AsyncNodeStorage } from 'redux-persist-node-storage'
 import { persistStore, autoRehydrate } from 'redux-persist'
 const store = createStore(reducer, undefined, autoRehydrate())
-persistStore(store, { storage: new AsyncNodeStorage('/tmp/storageDir') })
+persistStore(store, { storage: new AsyncNodeStorage('/tmp/storageDir', 10) }) // 10MB limit for storage
 ``` 

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,8 +3,8 @@ import { LocalStorage } from 'node-localstorage'
 export class AsyncNodeStorage {
   private localStorage: LocalStorage
 
-  constructor(storageDirectory: string) {
-    this.localStorage = new LocalStorage(storageDirectory)
+  constructor(storageDirectory: string, maxStorageeSize: number = 5) {
+    this.localStorage = new LocalStorage(storageDirectory, maxStorageeSize * 1024 * 1024)
   }
 
   getItem (key: string) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,8 +3,8 @@ import { LocalStorage } from 'node-localstorage'
 export class AsyncNodeStorage {
   private localStorage: LocalStorage
 
-  constructor(storageDirectory: string, maxStorageeSize: number = 5) {
-    this.localStorage = new LocalStorage(storageDirectory, maxStorageeSize * 1024 * 1024)
+  constructor(storageDirectory: string, maxStorageSize: number = 5) {
+    this.localStorage = new LocalStorage(storageDirectory, maxStorageSize * 1024 * 1024)
   }
 
   getItem (key: string) {


### PR DESCRIPTION
Right now the storage size is limited at 5MB because of `node-localstorage` has a parameter that is not being set. So I have added the option to do it.